### PR TITLE
Allow the use of special characters in story titles

### DIFF
--- a/Core/src/main/java/nl/mikero/turntopassage/core/TwinePublishedRepairer.java
+++ b/Core/src/main/java/nl/mikero/turntopassage/core/TwinePublishedRepairer.java
@@ -34,7 +34,7 @@ public class TwinePublishedRepairer implements TwineRepairer {
      * of arguments) and close tags and anything in between (including
      * newlines).
      */
-    private static final Pattern REGEX_TW_STORYDATA = Pattern.compile("(?s)<tw-storydata ([\\s\\w=\"'\\-.]*)>(.*)<\\/tw-storydata>");
+    private static final Pattern REGEX_TW_STORYDATA = Pattern.compile("(?s)<tw-storydata (.*)>(.*)<\\/tw-storydata>");
 
     private static final String ELEM_TW_STORIESDATA = "tw-storiesdata";
     private static final String ELEM_TW_STORYDATA = "tw-storydata";

--- a/Core/src/test/java/nl/mikero/turntopassage/core/TwinePublishedRepairerTest.java
+++ b/Core/src/test/java/nl/mikero/turntopassage/core/TwinePublishedRepairerTest.java
@@ -57,6 +57,24 @@ public class TwinePublishedRepairerTest extends TwineRepairerTest {
     }
 
     @Test
+    public void repair_SpecialCharactersInTitle_ReturnsValidTwineXml() throws Exception {
+        // Arrange
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        // Act
+        try(InputStream inputStream = getClass().getResourceAsStream("/html/special-character-title.html")) {
+            repairer.repair(inputStream, outputStream);
+        }
+
+        // Assert
+        validate(outputStream);
+
+        // If we reach this point, the returned XML is valid. Yay!
+        Assert.assertTrue(true);
+        outputStream.close();
+    }
+
+    @Test
     public void repair_SubarQubeStoryFormat_ReturnsValidTwineXml() throws Exception {
         // Arrange
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/Core/src/test/resources/html/special-character-title.html
+++ b/Core/src/test/resources/html/special-character-title.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Harlowe
+</title>
+<meta charset="utf-8"><style>body{font:18px "Helvetica Neue",Helvetica,Arial,sans-serif;color:#222}#passage{max-width:38em;margin:0 auto;line-height:145%}a{color:#222;text-decoration:none;border-bottom:2px solid #bbb}a:hover{color:#cc8929;border-color:#cc8929}a:active{color:#ffb040;border-color:#ffb040}tw-storydata{display:none}@media screen and (max-device-width:480px){#passage{font-size:70%}}</style>
+
+</head>
+<body>
+<div id="passage"></div><tw-storydata name="Special - Châracters @ In # This % Néme" startnode="1" creator="Twine" creator-version="2.0.4" ifid="10EF1FE4-5F55-4BB3-81A7-D9637A1DCDDA" format="Snowman" options=""><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css"></style><script role="script" id="twine-user-script" type="text/twine-javascript"></script><tw-passagedata pid="1" name="First Passage" tags="" position="800,250">Lorum ipsum dolor sit amet.
+
+[[Second Passage]]</tw-passagedata><tw-passagedata pid="2" name="Second Passage" tags="some-tag" position="800,425">Wow! This one has a tag!</tw-passagedata></tw-storydata>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The following Twine features are currently supported:
 
 * Markdown syntax for passages
 * Standard passage links (e.g. [[displayed text|passage title]], [[passage title]])
+* Story Stylesheet
 
 ## Usage
 
@@ -56,9 +57,6 @@ roughly:
   <dt>Images</dt>
   <dd>The ability to add (local and remote) images to a Twine story using standard markdown syntax. Images will be
   downloaded or copied to the EPUB file.</dd>
-  <dt>CSS</dt>
-  <dd>The ability to add (local) stylesheets. Stylesheets will be copied to the EPUB file and included in the XHTML
-  files.</dd>
   <dt>Static Passage Choice Magic (tm)</dt>
   <dd>The ability to use really trivial switches and conditionals and have TurnToPassage calculate all possible paths to
   put into a static EPUB file. Don't expect this any time soon, or ever. Just an idea.</dd>


### PR DESCRIPTION
This fix allows the use of special characters in story titles (or any attribute realy) by relaxing the regex pattern use to find the root xml tag.