### PR TITLE
Embedding remote images

### DIFF
--- a/Core/src/main/java/nl/mikero/turntopassage/core/embedder/Embedder.java
+++ b/Core/src/main/java/nl/mikero/turntopassage/core/embedder/Embedder.java
@@ -4,6 +4,8 @@ import nl.mikero.turntopassage.core.model.TwPassagedata;
 import nl.siegmann.epublib.domain.Book;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
 
 /**
  * Embeds a resources and defines the naming and location in the EPUB file.
@@ -17,7 +19,7 @@ public interface Embedder {
      * @param url url of the image as defined by the user in twine
      * @return path of resource inside the EPUB file
      */
-    String getHref(String url) throws IOException;
+    String getHref(URL url) throws IOException;
 
     /**
      * Embeds the resource at the given {@code url} in the given {@link Book}.
@@ -25,6 +27,6 @@ public interface Embedder {
      * @param book book to embed resource in
      * @param url url to resource that should be embedded
      */
-    void embed(Book book, String url) throws IOException;
+    void embed(Book book, URL url) throws IOException;
 
 }

--- a/Core/src/main/java/nl/mikero/turntopassage/core/embedder/ImageEmbedder.java
+++ b/Core/src/main/java/nl/mikero/turntopassage/core/embedder/ImageEmbedder.java
@@ -7,10 +7,13 @@ import nl.siegmann.epublib.domain.Resource;
 import nl.siegmann.epublib.service.MediatypeService;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.FileNameMap;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -46,47 +49,34 @@ public class ImageEmbedder implements Embedder {
      *
      * @param url url of the image as defined by the user in twine
      */
-    public String getHref(String url) throws IOException {
-        String hash = DigestUtils.sha256Hex(IOUtils.toByteArray(Files.newInputStream(Paths.get(url))));
-        return getFileName(hash, Paths.get(url));
+    public String getHref(URL url) throws IOException {
+        String hash = DigestUtils.sha256Hex(url.openStream());
+        return getFileName(hash, url);
     }
 
-    /**
-     * Embeds an image resource inside the EPUB archive.
-     *
-     * @param book book to embed the image in
-     * @param url url to the image
-     * @throws IOException when an I/O errors occurs with reading the input file
-     */
-    @Override
-    public void embed(Book book, String url) throws IOException {
-        embed(book, Paths.get(url));
-    }
-
-    public void embed(Book book, Path path) throws IOException {
+    public void embed(Book book, URL url) throws IOException {
         Objects.requireNonNull(book);
-        Objects.requireNonNull(path);
+        Objects.requireNonNull(url);
 
         // read and hash file
         byte[] fileContent = new byte[0];
-        try(InputStream in = Files.newInputStream(path)) {
+        try(InputStream in = url.openStream()) {
             DigestInputStream dis = new DigestInputStream(in, messageDigest);
             fileContent = IOUtils.toByteArray(dis);
         }
 
         // create resource
-        String fileName = getFileName(new String(Hex.encodeHex(messageDigest.digest())), path.getFileName());
-        Resource imgResource = new Resource(null, fileContent, fileName, MediatypeService.determineMediaType(path.getFileName().toString()));
+        String fileName = getFileName(new String(Hex.encodeHex(messageDigest.digest())), url);
+        Resource imgResource = new Resource(null, fileContent, fileName, MediatypeService.determineMediaType(FilenameUtils.getName(url.toString())));
 
         book.addResource(imgResource);
 
         messageDigest.reset();
     }
 
-    private String getFileName(String hash, Path originalPath) {
-        System.out.println(hash);
-        String originalFileName = originalPath.getFileName().toString();
-        String originalExtension = originalFileName.substring(originalFileName.lastIndexOf('.'));
+    private String getFileName(String hash, URL url) {
+        String originalFileName = FilenameUtils.getName(url.toString());
+        String originalExtension = FilenameUtils.getExtension(originalFileName);
 
         return "Images/" + hash + originalExtension;
     }

--- a/Core/src/main/java/nl/mikero/turntopassage/core/embedder/ResourceEmbedder.java
+++ b/Core/src/main/java/nl/mikero/turntopassage/core/embedder/ResourceEmbedder.java
@@ -8,6 +8,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
 
 /**
  * Runs through all nodes in a pegdown document and embeds any resource that
@@ -84,12 +88,22 @@ public class ResourceEmbedder implements Visitor {
     public void visit(ExpImageNode node) {
         try {
             Embedder embedder = factory.get(node);
-            embedder.embed(this.book, node.url);
+            embedder.embed(this.book, createUrlFromString(node.url));
         } catch (IOException e) {
             LOGGER.error("Error during embedding of '{}'", node.url, e);
         }
 
         visitChildren(node);
+    }
+
+    private URL createUrlFromString(String url) {
+        try {
+            return new URL(url);
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        }
+
+        return null;
     }
 
     @Override

--- a/Core/src/main/java/nl/mikero/turntopassage/core/pegdown/plugin/TwineLinkRenderer.java
+++ b/Core/src/main/java/nl/mikero/turntopassage/core/pegdown/plugin/TwineLinkRenderer.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -88,7 +89,7 @@ public class TwineLinkRenderer extends LinkRenderer {
     public Rendering render(ExpImageNode node, String text) {
         String url = node.url;
         try {
-            url = imageEmbedder.getHref(node.url);
+            url = imageEmbedder.getHref(new URL(node.url));
         } catch (IOException e) {
             // there's nothing we can do but continue
             LOGGER.error("Could not load image at url '{}'.", node.url, e);

--- a/Core/src/main/java/nl/mikero/turntopassage/core/transformer/TwineStoryEpubTransformer.java
+++ b/Core/src/main/java/nl/mikero/turntopassage/core/transformer/TwineStoryEpubTransformer.java
@@ -92,7 +92,7 @@ public class TwineStoryEpubTransformer {
         }
         
         // embed all resources
-        embedREsources(book, story);
+        embedResources(book, story);
 
         // add all passages
         try {

--- a/Core/src/test/java/nl/mikero/turntopassage/core/embedder/ImageEmbedderTest.java
+++ b/Core/src/test/java/nl/mikero/turntopassage/core/embedder/ImageEmbedderTest.java
@@ -8,7 +8,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
@@ -33,7 +35,7 @@ public class ImageEmbedderTest {
         // Arrange
 
         // Act
-        embedder.embed(null, "/img/doesnotexist.png");
+        embedder.embed(null, new URL("file:/img/doesnotexist.png"));
 
         // Assert
     }
@@ -43,7 +45,7 @@ public class ImageEmbedderTest {
         // Arrange
 
         // Act
-        embedder.embed(null, "/img/doesnotexist.png");
+        embedder.embed(null, new URL("file:/img/doesnotexist.png"));
 
         // Assert
     }
@@ -54,11 +56,11 @@ public class ImageEmbedderTest {
         Book book = new Book();
 
         // Act
-        embedder.embed(book, Paths.get(getClass().getResource("/embed/image.jpg").toURI()));
-        embedder.embed(book, Paths.get(getClass().getResource("/embed/image.jpeg").toURI()));
-        embedder.embed(book, Paths.get(getClass().getResource("/embed/image.png").toURI()));
-        embedder.embed(book, Paths.get(getClass().getResource("/embed/image.gif").toURI()));
-        embedder.embed(book, Paths.get(getClass().getResource("/embed/image.svg").toURI()));
+        embedder.embed(book, getClass().getResource("/embed/image.jpg").toURI().toURL());
+        embedder.embed(book, getClass().getResource("/embed/image.jpeg").toURI().toURL());
+        embedder.embed(book, getClass().getResource("/embed/image.png").toURI().toURL());
+        embedder.embed(book, getClass().getResource("/embed/image.gif").toURI().toURL());
+        embedder.embed(book, getClass().getResource("/embed/image.svg").toURI().toURL());
 
         // Assert
         Resources resources = book.getResources();
@@ -90,7 +92,7 @@ public class ImageEmbedderTest {
         Book book = new Book();
 
         // Act
-        embedder.embed(book, Paths.get(getClass().getResource("/embed/image.bmp").toURI()));
+        embedder.embed(book, getClass().getResource("/embed/image.bmp").toURI().toURL());
 
         // Assert
         assertEquals(1, book.getResources().size());
@@ -102,7 +104,7 @@ public class ImageEmbedderTest {
         Book book = new Book();
 
         // Act
-        embedder.embed(book, "/does/not/exist");
+        embedder.embed(book, new URL("file:/does/not/exist"));
 
         // Assert
     }
@@ -111,12 +113,12 @@ public class ImageEmbedderTest {
     public void embed_ValidResource_HrefAndEmbedHashAreEqual() throws Exception {
         // Arrange
         Book book = new Book();
-        Path path = Paths.get(getClass().getResource("/embed/image.png").toURI());
+        URL url = getClass().getResource("/embed/image.png").toURI().toURL();
 
         // Act
 
-        embedder.embed(book, path);
-        String result = embedder.getHref(path.toString());
+        embedder.embed(book, url);
+        String result = embedder.getHref(url);
 
         // Assert
         List<Resource> pngs = book.getResources().getResourcesByMediaType(MediatypeService.PNG);

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The following Twine features are currently supported:
 * Markdown syntax for passages
 * Standard passage links (e.g. [[displayed text|passage title]], [[passage title]])
 * Story Stylesheet
-* Images
+* Local and remote images
 
 ## Usage
 
@@ -55,12 +55,6 @@ roughly:
   <dd>The ability to set any metadata from inside a private Twine passage.</dd>
   <dt>Annotation tag</dt>
   <dd>Passages tagged with `annotation` will not be included in the EPUB file.</dd>
-  <dt>Images</dt>
-  <dd>The ability to add (local and remote) images to a Twine story using standard markdown syntax. Images will be
-  downloaded or copied to the EPUB file.</dd>
-  <dt>Remote Images</dt>
-  <dd>The ability to add remote images to a Twine story using standard markdown syntax. Images will be downloaded and 
-  copied to the EPUB file.</dd>
   <dt>Static Passage Choice Magic (tm)</dt>
   <dd>The ability to use really trivial switches and conditionals and have TurnToPassage calculate all possible paths to
   put into a static EPUB file. Don't expect this any time soon, or ever. Just an idea.</dd>


### PR DESCRIPTION
Allows the embedding of remote images using simple markdown syntax. Local files not need a valid URL structure using the `file` protocol (e.g. `file:/C:\User\My Pictures\koala.png` will work). 